### PR TITLE
Allow to specify relative paths for CustomDictionariesFolder.

### DIFF
--- a/source/YouShouldSpellcheck.Analyzer.Test/SpellcheckSettingsTests.cs
+++ b/source/YouShouldSpellcheck.Analyzer.Test/SpellcheckSettingsTests.cs
@@ -1,0 +1,23 @@
+﻿
+namespace YouShouldSpellcheck.Analyzer.Test
+{
+  using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+  [TestClass]
+  public class SpellcheckSettingsTests
+  {
+    [TestMethod]
+    public void TestCustomDictionariesFolder()
+    {
+      var relativePath = new SpellcheckSettingsWrapper(new SpellcheckSettings { CustomDictionariesFolder = @"..\test\dic" }, @"C:\config-folder\config.xml");
+      var absolutePath = new SpellcheckSettingsWrapper(new SpellcheckSettings { CustomDictionariesFolder = @"C:\my-custom\dic" }, @"C:\config.xml");
+      var envPath = new SpellcheckSettingsWrapper(new SpellcheckSettings { CustomDictionariesFolder = @"%SystemRoot%\dic" }, @"C:\config.xml");
+      var envPath2 = new SpellcheckSettingsWrapper(new SpellcheckSettings { CustomDictionariesFolder = @"%SystemRoot%\..\test\dic" }, @"C:\config.xml");
+
+      Assert.AreEqual(@"c:\test\dic", relativePath.CustomDictionariesFolder.ToLower());
+      Assert.AreEqual(@"c:\my-custom\dic", absolutePath.CustomDictionariesFolder.ToLower());
+      Assert.AreEqual(@"c:\windows\dic", envPath.CustomDictionariesFolder.ToLower());
+      Assert.AreEqual(@"c:\test\dic", envPath2.CustomDictionariesFolder.ToLower());
+    }
+  }
+}

--- a/source/YouShouldSpellcheck.Analyzer.Test/YouShouldSpellcheck.Analyzer.Test.csproj
+++ b/source/YouShouldSpellcheck.Analyzer.Test/YouShouldSpellcheck.Analyzer.Test.csproj
@@ -103,6 +103,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SpellcheckSettingsTests.cs" />
     <Compile Include="Verifiers\CodeFixVerifier.cs" />
     <Compile Include="Verifiers\DiagnosticVerifier.cs" />
     <Compile Include="Helpers\CodeFixVerifier.Helper.cs" />

--- a/source/YouShouldSpellcheck.Analyzer/AnalyzerContext.cs
+++ b/source/YouShouldSpellcheck.Analyzer/AnalyzerContext.cs
@@ -53,7 +53,7 @@
       return GetSpellcheckSettings(options?.AdditionalFiles ?? ImmutableArray.Create<AdditionalText>(), cancellationToken);
     }
 
-    private static ISpellcheckSettings GetSpellcheckSettingsFromTextFile(SourceText settingsXml)
+    private static ISpellcheckSettings GetSpellcheckSettingsFromTextFile(SourceText settingsXml, string settingsPath)
     {
       using (var spellcheckSettingsAsTemporaryMemoryStream = new MemoryStream())
       using (var temporaryStreamWriter = new StreamWriter(spellcheckSettingsAsTemporaryMemoryStream))
@@ -61,11 +61,11 @@
         settingsXml.Write(temporaryStreamWriter);
         temporaryStreamWriter.Flush();
         spellcheckSettingsAsTemporaryMemoryStream.Position = 0;
-        return GetSpellcheckSettings(spellcheckSettingsAsTemporaryMemoryStream);
+        return GetSpellcheckSettings(spellcheckSettingsAsTemporaryMemoryStream, settingsPath);
       }
     }
 
-    private static ISpellcheckSettings GetSpellcheckSettings(Stream settingsXml)
+    private static ISpellcheckSettings GetSpellcheckSettings(Stream settingsXml, string settingsPath)
     {
       try
       {
@@ -73,7 +73,7 @@
         var deserializedSpellcheckSettings = spellcheckSettingsSerializer.Deserialize(settingsXml) as SpellcheckSettings;
         if (deserializedSpellcheckSettings != null)
         {
-          spellcheckSettings = new SpellcheckSettingsWrapper(deserializedSpellcheckSettings);
+          spellcheckSettings = new SpellcheckSettingsWrapper(deserializedSpellcheckSettings, settingsPath);
           return spellcheckSettings;
         }
 
@@ -94,7 +94,7 @@
           var additionalTextContent = additionalFile.GetText(cancellationToken);
           additionalTextContent.Container.TextChanged += SpellcheckSettingsChanged;
 
-          return GetSpellcheckSettingsFromTextFile(additionalTextContent);
+          return GetSpellcheckSettingsFromTextFile(additionalTextContent, additionalFile.Path);
         }
       }
 


### PR DESCRIPTION
With this change, it's possible to configure a path that is relative to the configuration file as CustomDictionariesFolder.
Add a unit test to ensure that different paths are supported.